### PR TITLE
Fix serverlist url, current url returns a 404 error

### DIFF
--- a/scripts/run
+++ b/scripts/run
@@ -103,7 +103,7 @@ get_servers () {
             echo "$(date): Fetching and verifying modern PIA server list"
             tmp_allow_host "serverlist.piaservers.net" 443
             SERVERLIST=$(curl --silent --show-error --max-time $CURL_MAX_TIME --resolve "serverlist.piaservers.net:443:$IP" \
-                "https://serverlist.piaservers.net/vpninfo/servers/new")
+                "https://serverlist.piaservers.net/vpninfo/servers/v6")
             verify_serverlist
         fi
 


### PR DESCRIPTION
Hi, 

I've got issues tonight to make my containers work again after rebooting since the current url that used to provide the serverlist is now returning a 404 error.
This has apparently already been fixed in the repo you forked so I backported the change in this PR.

Btw thanks for your work, it's really useful. :)